### PR TITLE
Sync course appearance with public group form

### DIFF
--- a/src/componentes/PantallaCursos/CourseModal.jsx
+++ b/src/componentes/PantallaCursos/CourseModal.jsx
@@ -169,6 +169,18 @@ export default function CourseModal({
           imageUrl: imagePreview || initialData.imageUrl || '',
           updatedAt: new Date(),
         });
+        if (initialData.encuestaId) {
+          try {
+            await updateDoc(doc(db, 'encuestas', initialData.encuestaId), {
+              titulo: `Registro de Grupos – ${form.titulo || ''}`,
+              descripcion: form.descripcion || '',
+              theme: form.theme,
+              updatedAt: new Date(),
+            });
+          } catch (err) {
+            console.error('update encuesta:', err);
+          }
+        }
         // opcional: feedback visual
         // alert('Cambios guardados');
       } catch (err) {

--- a/src/componentes/PantallaCursos/DetailsModal.jsx
+++ b/src/componentes/PantallaCursos/DetailsModal.jsx
@@ -108,7 +108,9 @@ export default function DetailsModal({
         const res = await createForCourse({
           cursoId: data.id,
           titulo: `Registro de Grupos – ${data.titulo || ''}`,
+          descripcion: data.descripcion || '',
           preguntas,
+          theme,
           user: null,
         });
         id = res.id;
@@ -125,6 +127,8 @@ export default function DetailsModal({
           link,
           linkSlug: slug,
           theme,
+          titulo: `Registro de Grupos – ${data.titulo || ''}`,
+          descripcion: data.descripcion || '',
           updatedAt: new Date(),
         });
       } catch (e) {

--- a/src/utilidades/useCourses.js
+++ b/src/utilidades/useCourses.js
@@ -41,6 +41,9 @@ export function useCourses() {
               reportes: data.reportes || [],
               imageUrl: data.imageUrl || '',
               tipoCurso: data.tipoCurso || 'personal',
+              theme: data.theme || {},
+              encuestaId: data.encuestaId || '',
+              encuestaLink: data.encuestaLink || '',
               formularioGrupos: data.formularioGrupos || {
                 camposPreestablecidos: {
                   nombreEquipo: true,
@@ -89,6 +92,9 @@ export function useCourses() {
         reportes: [],
         imageUrl,
         tipoCurso: courseData.tipoCurso || 'personal',
+        theme: courseData.theme || {},
+        encuestaId: courseData.encuestaId || '',
+        encuestaLink: courseData.encuestaLink || '',
         formularioGrupos: courseData.formularioGrupos || {
           camposPreestablecidos: {
             nombreEquipo: true,
@@ -136,6 +142,9 @@ export function useCourses() {
       descripcion: courseData.descripcion,
       listas: Array.isArray(courseData.lista) ? courseData.lista : [],
       tipoCurso: courseData.tipoCurso || 'personal',
+      theme: courseData.theme || {},
+      encuestaId: courseData.encuestaId || '',
+      encuestaLink: courseData.encuestaLink || '',
       formularioGrupos: courseData.formularioGrupos || {
         camposPreestablecidos: {
           nombreEquipo: true,

--- a/src/utilidades/useSurveys.js
+++ b/src/utilidades/useSurveys.js
@@ -1,5 +1,5 @@
 // src/utilidades/useSurveys.js
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { db } from '../servicios/firebaseConfig';
 import {
   collection, doc, addDoc, getDoc, getDocs, query, where, updateDoc,
@@ -23,17 +23,20 @@ export function useSurveys() {
     return snap.exists() ? ({ id: snap.id, ...snap.data() }) : null;
   }, []);
 
-  const createForCourse = useCallback(async ({ cursoId, titulo, preguntas, user }) => {
-    setLoading(true);
-    try {
-      const ref = await addDoc(collection(db, ENCUESTAS), {
-        cursoId,
+  const createForCourse = useCallback(
+    async ({ cursoId, titulo, descripcion, preguntas, theme, user }) => {
+      setLoading(true);
+      try {
+        const ref = await addDoc(collection(db, ENCUESTAS), {
+          cursoId,
         titulo: titulo || 'Registro de Grupos',
+        descripcion: descripcion || '',
         preguntas: preguntas || [],
+        theme: theme || {},
         creadoPor: user?.uid || null,
         creadoEn: serverTimestamp(),
         link: '' // luego lo rellenamos
-      });
+        });
 
       // Detecta si la app usa HashRouter (window.location.hash comienza con "#/")
       const usesHashRouter = window.location.hash?.startsWith('#/');


### PR DESCRIPTION
## Summary
- Sync edited course data with its survey, pushing title, description, and theme updates
- Include description and appearance data when creating or updating surveys
- Persist course theme and survey references in course records

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 20 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ed3d165c83268a889988f0140c32