### PR TITLE
Clear course form state and cleanup surveys on course deletion

### DIFF
--- a/src/componentes/PantallaCursos/CourseModal.jsx
+++ b/src/componentes/PantallaCursos/CourseModal.jsx
@@ -16,7 +16,14 @@ export default function CourseModal({
     overlayOpacity: 0.35,
   };
 
-  const [form, setForm] = useState({
+  const emptyQuestion = {
+    titulo: '',
+    tipo: 'abierta',
+    requerida: false,
+    opciones: [],
+  };
+
+  const createInitialForm = () => ({
     titulo: '',
     instructor: '',
     fechaInicio: '',
@@ -37,18 +44,15 @@ export default function CourseModal({
     },
   });
 
+  const [form, setForm] = useState(createInitialForm());
+
   // imagen de portada del curso (no es la de la pantalla del formulario)
   const [imageFile, setImageFile] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
 
   const [personalList, setPersonalList] = useState([]);
   const [editandoPregunta, setEditandoPregunta] = useState(null);
-  const [nuevaPregunta, setNuevaPregunta] = useState({
-    titulo: '',
-    tipo: 'abierta',
-    requerida: false,
-    opciones: [],
-  });
+  const [nuevaPregunta, setNuevaPregunta] = useState(emptyQuestion);
   const [searchPersonal, setSearchPersonal] = useState('');
   const [filterArea, setFilterArea] = useState('');
 
@@ -56,6 +60,7 @@ export default function CourseModal({
 
   // Cargar datos iniciales al abrir/editar
   useEffect(() => {
+    if (!isOpen) return;
     if (initialData.id) {
       const existentes = Array.isArray(initialData.lista) ? initialData.lista : [];
       setForm({
@@ -80,11 +85,13 @@ export default function CourseModal({
       });
       if (initialData.imageUrl) setImagePreview(initialData.imageUrl);
     } else {
-      setForm(f => ({ ...f, theme: defaultTheme }));
+      setForm(createInitialForm());
       setImageFile(null);
       setImagePreview(null);
+      setEditandoPregunta(null);
+      setNuevaPregunta(emptyQuestion);
     }
-  }, [initialData]);
+  }, [initialData, isOpen]);
 
   // Personal
   useEffect(() => {
@@ -438,7 +445,6 @@ export default function CourseModal({
               personalList={personalList}
               personalFiltrado={personalFiltrado}
               form={form}
-              setForm={setForm}
               searchPersonal={searchPersonal}
               setSearchPersonal={setSearchPersonal}
               filterArea={filterArea}
@@ -463,7 +469,7 @@ export default function CourseModal({
 /* ===================== Sub-secciones ===================== */
 
 function PersonalSection({
-  personalList, personalFiltrado, form, setForm,
+  personalList, personalFiltrado, form,
   searchPersonal, setSearchPersonal, filterArea, setFilterArea, handlePersonalToggle
 }) {
   return (

--- a/src/utilidades/useCourses.js
+++ b/src/utilidades/useCourses.js
@@ -9,6 +9,8 @@ import {
   query,
   orderBy,
   serverTimestamp,
+  where,
+  getDocs,
 } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { db, storage } from '../servicios/firebaseConfig';
@@ -165,6 +167,19 @@ export function useCourses() {
 
   const deleteCourse = async (id) => {
     const cRef = doc(db, 'Cursos', id);
+
+    // Eliminar encuestas asociadas al curso
+    const q = query(collection(db, 'encuestas'), where('cursoId', '==', id));
+    const encuestasSnap = await getDocs(q);
+    for (const encDoc of encuestasSnap.docs) {
+      // Eliminar respuestas de la encuesta
+      const respSnap = await getDocs(collection(encDoc.ref, 'respuestas'));
+      for (const r of respSnap.docs) {
+        await deleteDoc(r.ref);
+      }
+      await deleteDoc(encDoc.ref);
+    }
+
     await deleteDoc(cRef);
   };
 


### PR DESCRIPTION
## Summary
- Reset course creation modal to a clean state each time it's opened
- Remove survey documents and their responses when deleting a course

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 24 problems, 19 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f176323083268f988d8671d3d291