### PR TITLE
fix: correct course deletion and isolate form appearance

### DIFF
--- a/src/servicios/cursos.js
+++ b/src/servicios/cursos.js
@@ -15,8 +15,8 @@ export async function deleteCourseAndSurveys(cursoId) {
   const batch = writeBatch(db);
   snap.docs.forEach(d => batch.delete(d.ref));
 
-  // 2) curso
-  batch.delete(doc(db, 'cursos', cursoId));
+  // 2) curso (colección 'Cursos')
+  batch.delete(doc(db, 'Cursos', cursoId));
 
   await batch.commit();
 }

--- a/src/utilidades/useFormAppearance.js
+++ b/src/utilidades/useFormAppearance.js
@@ -11,7 +11,8 @@ const DEFAULTS = {
 };
 
 export function useFormAppearance(formId) {
-  const [appearance, setAppearance] = useState(DEFAULTS);
+  // Usa una copia para evitar referencias compartidas entre formularios
+  const [appearance, setAppearance] = useState(() => ({ ...DEFAULTS }));
   const [loading, setLoading] = useState(true);
   const objectUrlRef = useRef(null);
 
@@ -25,7 +26,7 @@ export function useFormAppearance(formId) {
       setLoading(true);
       try {
         if (!formId) {
-          if (mounted) setAppearance(DEFAULTS);
+          if (mounted) setAppearance({ ...DEFAULTS });
           return;
         }
         const snap = await getDoc(doc(db, 'formularios', formId));
@@ -41,7 +42,7 @@ export function useFormAppearance(formId) {
       }
     }
     // reset duro + carga
-    setAppearance(DEFAULTS);
+    setAppearance({ ...DEFAULTS });
     load();
 
     return () => {


### PR DESCRIPTION
## Summary
- fix deleting courses using proper `Cursos` collection
- avoid sharing default appearance object across forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars, no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68c46f9426a48326bd9647aa7e73edbd