### PR TITLE
Add team management actions and export participant names

### DIFF
--- a/src/paginas/RegistroGrupo.jsx
+++ b/src/paginas/RegistroGrupo.jsx
@@ -252,7 +252,6 @@ export default function RegistroGrupo() {
   if (!encuesta) return <div className="p-6">Formulario no encontrado.</div>;
   if (ok)
     return (
-
       <div className="min-h-screen" style={containerStyle}>
         {theme._bgUrl && theme.overlayOpacity > 0 && (
           <div
@@ -260,27 +259,12 @@ export default function RegistroGrupo() {
             style={{ background: `rgba(0,0,0,${theme.overlayOpacity})` }}
           />
         )}
-
-        <div className="relative z-10 max-w-3xl mx-auto p-6">
+        <div className="relative z-10 flex items-center justify-center max-w-3xl mx-auto p-6">
           <div className="rounded-xl bg-white/90 backdrop-blur shadow-xl p-10 text-center">
             <div className="text-5xl mb-4">✅</div>
             <h2 className="text-xl font-semibold mb-2">¡Registro enviado!</h2>
-            <p className="text-gray-600">Gracias por registrar tu equipo.</p>
+            <p className="text-gray-600 mb-6">Gracias por registrar tu equipo.</p>
           </div>
-
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
-        <div className="bg-white rounded-lg shadow-md p-8 text-center">
-          <div className="text-5xl mb-4">✅</div>
-          <h2 className="text-xl font-semibold mb-2">¡Registro enviado!</h2>
-          <p className="text-gray-600 mb-6">Gracias por registrar tu equipo.</p>
-          <button
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-            onClick={() => setOk(false)}
-          >
-            Registrar otro equipo
-          </button>
-
-
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Enable view, edit, and delete buttons for teams in course details
- Export Excel with participant names and track integrants
- Remove duplicate "Registrar otro equipo" button from success screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6821a1dc88326aeae1fa0a25c13c2