### PR TITLE
Add Categoria preset field to group registration

### DIFF
--- a/src/componentes/PantallaCursos/CourseModal.jsx
+++ b/src/componentes/PantallaCursos/CourseModal.jsx
@@ -49,11 +49,12 @@ export default function CourseModal({
         nombreEquipo: true,
         nombreLider: true,
         contactoEquipo: true,
+        categoria: true,
         cantidadParticipantes: true,
       },
       cantidadParticipantes: 1,
       preguntasPersonalizadas: [],
-      
+
     },
   }), []);
 
@@ -109,6 +110,7 @@ export default function CourseModal({
             nombreEquipo: true,
             nombreLider: true,
             contactoEquipo: true,
+            categoria: true,
             cantidadParticipantes: true, // ⬅️ nuevo campo
             ...(initialData.formularioGrupos?.camposPreestablecidos || {}),
           },
@@ -228,6 +230,7 @@ const submit = async (e) => {
     nombreEquipo: true,
     nombreLider: true,
     contactoEquipo: true,
+    categoria: true,
     cantidadParticipantes: true,
     ...(form.formularioGrupos?.camposPreestablecidos || {}),
   };
@@ -651,7 +654,8 @@ function GruposSection({
             { key: 'nombreEquipo', label: 'Nombre del Equipo' },
             { key: 'nombreLider', label: 'Nombre del Líder del Equipo' },
             { key: 'contactoEquipo', label: 'Contacto del Equipo' },
-              { key: 'cantidadParticipantes', label: 'Cantidad de Participantes' },
+            { key: 'categoria', label: 'Categoría' },
+            { key: 'cantidadParticipantes', label: 'Cantidad de Participantes' },
           ].map(c => (
             <label key={c.key} className="flex items-center">
               <input
@@ -936,6 +940,12 @@ function GruposSection({
               Contacto del Equipo (requerido)
             </div>
           )}
+          {form.formularioGrupos.camposPreestablecidos.categoria && (
+            <div className="flex items-center text-gray-600">
+              <span className="w-2 h-2 bg-blue-400 rounded-full mr-2"></span>
+              Categoría (requerido)
+            </div>
+          )}
           {form.formularioGrupos.camposPreestablecidos.cantidadParticipantes && (
            <div className="flex items-center text-gray-600">
              <span className="w-2 h-2 bg-blue-400 rounded-full mr-2"></span>
@@ -954,6 +964,7 @@ function GruposSection({
           {form.formularioGrupos.camposPreestablecidos.nombreEquipo === false &&
            form.formularioGrupos.camposPreestablecidos.nombreLider === false &&
            form.formularioGrupos.camposPreestablecidos.contactoEquipo === false &&
+           form.formularioGrupos.camposPreestablecidos.categoria === false &&
            form.formularioGrupos.preguntasPersonalizadas.length === 0 && (
             <div className="text-gray-400 italic">No hay campos configurados</div>
           )}

--- a/src/componentes/PantallaCursos/DetailsModal.jsx
+++ b/src/componentes/PantallaCursos/DetailsModal.jsx
@@ -128,6 +128,7 @@ export default function DetailsModal({
     nombreEquipo: true,
     nombreLider: true,
     contactoEquipo: true,
+    categoria: true,
     cantidadParticipantes: true,
   },
 });
@@ -154,6 +155,7 @@ export default function DetailsModal({
     nombreEquipo: true,
     nombreLider: true,
     contactoEquipo: true,
+    categoria: true,
     cantidadParticipantes: true,
   },
   updatedAt: new Date(),
@@ -482,12 +484,19 @@ function CuestionarioPreview({ data }) {
               <span className="ml-auto text-red-500 text-sm">*</span>
             </div>
           )}
+          {data.formularioGrupos?.camposPreestablecidos?.categoria && (
+            <div className="flex items-center bg-white p-3 rounded-lg shadow-sm">
+              <span className="text-blue-500 mr-3">🏷️</span>
+              <span className="text-gray-700 font-medium">Categoría</span>
+              <span className="ml-auto text-red-500 text-sm">*</span>
+            </div>
+          )}
           {data.formularioGrupos?.camposPreestablecidos?.cantidadParticipantes && (
            <div className="flex items-center bg-white p-3 rounded-lg shadow-sm">
            <span className="text-blue-500 mr-3">👥</span>
            <span className="text-gray-700 font-medium">Cantidad de Participantes</span>
-           <span className="ml-auto text-red-500 text-sm">*</span>
-           </div>
+            <span className="ml-auto text-red-500 text-sm">*</span>
+            </div>
           )}
         </div>
       </div>

--- a/src/paginas/RegistroGrupo.jsx
+++ b/src/paginas/RegistroGrupo.jsx
@@ -32,7 +32,7 @@ export default function RegistroGrupo() {
   const [formAppearance, setFormAppearance] = useState(null);
   const [loading,        setLoading]        = useState(true);
   const [preset,         setPreset]         = useState({
-    nombreEquipo: '', nombreLider: '', contactoEquipo: '',
+    nombreEquipo: '', nombreLider: '', contactoEquipo: '', categoria: '',
     cantidadParticipantes: 1, integrantes: [''],
   });
   const [custom,         setCustom]         = useState({});
@@ -114,6 +114,7 @@ export default function RegistroGrupo() {
     nombreEquipo: '',
     nombreLider: '',
     contactoEquipo: '',
+    categoria: '',
   }));
   setOk(false);
   setFormAppearance(null);
@@ -158,12 +159,13 @@ export default function RegistroGrupo() {
 
   // Re-inicializa campos preestablecidos cuando cambia su configuración
   useEffect(() => {
-    setPreset({ nombreEquipo: '', nombreLider: '', contactoEquipo: '',  });
+    setPreset({ nombreEquipo: '', nombreLider: '', contactoEquipo: '', categoria: '' });
   setOk(false);
   }, [
     encuesta?.camposPreestablecidos?.nombreEquipo,
     encuesta?.camposPreestablecidos?.nombreLider,
     encuesta?.camposPreestablecidos?.contactoEquipo,
+    encuesta?.camposPreestablecidos?.categoria,
    // ⬅️ asegura reset si cambian
   ]);
 
@@ -282,6 +284,7 @@ export default function RegistroGrupo() {
     nombreEquipo: true,
     nombreLider: true,
     contactoEquipo: true,
+    categoria: true,
     cantidadParticipantes: true,
   };
 
@@ -352,30 +355,43 @@ export default function RegistroGrupo() {
                 />
               </div>
             )}
-          
-{campos.cantidadParticipantes && cupo > 0 && (
-  <div className="space-y-4">
-    {Array.from({ length: cupo }).map((_, i) => (
-      <div key={i}>
-        <label className="block text-sm mb-1" style={{ color: theme.textColor || '#374151' }}>
-          Integrante {i + 1}
-        </label>
-        <input
-          className="border rounded px-3 py-2 w-full"
-          value={preset.integrantes?.[i] ?? ''}
-          onChange={(e) =>
-            setPreset(p => {
-              const next = resizeArray(p.integrantes, cupo);
-              next[i] = e.target.value;
-              return { ...p, integrantes: next };
-            })
-          }
-          required
-        />
-      </div>
-    ))}
-  </div>
-)}
+            {campos.categoria && (
+              <div>
+                <label className="block text-sm mb-1" style={{ color: theme.textColor || '#374151' }}>
+                  Categoría *
+                </label>
+                <input
+                  className="border rounded px-3 py-2 w-full"
+                  value={preset.categoria}
+                  onChange={(e) => setPreset((p) => ({ ...p, categoria: e.target.value }))}
+                  required
+                />
+              </div>
+            )}
+
+            {campos.cantidadParticipantes && cupo > 0 && (
+              <div className="space-y-4">
+                {Array.from({ length: cupo }).map((_, i) => (
+                  <div key={i}>
+                    <label className="block text-sm mb-1" style={{ color: theme.textColor || '#374151' }}>
+                      Integrante {i + 1}
+                    </label>
+                    <input
+                      className="border rounded px-3 py-2 w-full"
+                      value={preset.integrantes?.[i] ?? ''}
+                      onChange={(e) =>
+                        setPreset(p => {
+                          const next = resizeArray(p.integrantes, cupo);
+                          next[i] = e.target.value;
+                          return { ...p, integrantes: next };
+                        })
+                      }
+                      required
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
 
 
             {/* Preguntas personalizadas */}

--- a/src/utilidades/useCourses.js
+++ b/src/utilidades/useCourses.js
@@ -50,7 +50,9 @@ export function useCourses() {
                 camposPreestablecidos: {
                   nombreEquipo: true,
                   nombreLider: true,
-                  contactoEquipo: true
+                  contactoEquipo: true,
+                  categoria: true,
+                  cantidadParticipantes: true,
                 },
                 preguntasPersonalizadas: []
               },
@@ -101,7 +103,9 @@ export function useCourses() {
           camposPreestablecidos: {
             nombreEquipo: true,
             nombreLider: true,
-            contactoEquipo: true
+            contactoEquipo: true,
+            categoria: true,
+            cantidadParticipantes: true,
           },
           preguntasPersonalizadas: []
         },
@@ -151,7 +155,9 @@ export function useCourses() {
         camposPreestablecidos: {
           nombreEquipo: true,
           nombreLider: true,
-          contactoEquipo: true
+          contactoEquipo: true,
+          categoria: true,
+          cantidadParticipantes: true,
         },
         preguntasPersonalizadas: []
       }


### PR DESCRIPTION
## Summary
- add `categoria` to RegistroGrupo preset and form
- support `categoria` in course modals and details
- include `categoria` in course utilities

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c685af8a248326bf11a47d2f977bc2