### PR TITLE
Mejoras en constancias y gestión de categorías

### DIFF
--- a/src/componentes/PantallaCursos/CourseModal.jsx
+++ b/src/componentes/PantallaCursos/CourseModal.jsx
@@ -201,10 +201,13 @@ const submit = async (e) => {
 
   onSubmit?.({ ...form, imageUrl: imagePreview }, imageFile);
 
+  const cats = Array.from(new Set(form.formularioGrupos?.categorias || []));
+
   // Guarda el curso (cuando editas)
   if (isEdit) {
     await updateDoc(doc(db, 'Cursos', initialData.id), {
       ...form,
+      formularioGrupos: { ...form.formularioGrupos, categorias: cats },
       imageUrl: imagePreview || initialData.imageUrl || '',
       updatedAt: new Date(),
     });
@@ -249,7 +252,7 @@ const submit = async (e) => {
     formularioGrupos: {
       ...(initialData.formularioGrupos || {}),
       cantidadParticipantes: cantidad,
-      categorias: form.formularioGrupos.categorias || [],
+      categorias: cats,
     },
 
     // claves que lee RegistroGrupo
@@ -688,18 +691,23 @@ function GruposSection({
             className="border rounded px-3 py-2 w-full"
             rows={3}
             value={(form.formularioGrupos.categorias || []).join('\n')}
-            onChange={(e) =>
+            onChange={(e) => {
+              const cats = Array.from(
+                new Set(
+                  e.target.value
+                    .split('\n')
+                    .map((c) => c.trim())
+                    .filter(Boolean)
+                )
+              );
               setForm((prev) => ({
                 ...prev,
                 formularioGrupos: {
                   ...prev.formularioGrupos,
-                  categorias: e.target.value
-                    .split('\n')
-                    .map((c) => c.trim())
-                    .filter(Boolean),
+                  categorias: cats,
                 },
-              }))
-            }
+              }));
+            }}
           />
         </div>
       )}

--- a/src/paginas/Constancias.jsx
+++ b/src/paginas/Constancias.jsx
@@ -374,6 +374,38 @@ export default function Constancias() {
   // === Selección final según modo ===
   const sel = modo === 'individual' ? selInd : selEquip;
 
+  // Entidad utilizada para previsualizar datos en los cuadros de texto.
+  const previewEnt = useMemo(() => {
+    if (editId) return sel.find(e => e.id === editId) || null;
+    return sel.length === 1 ? sel[0] : null;
+  }, [editId, sel]);
+
+  const resolveMessage = (txt = '', ctx) => (
+    txt
+      .replace('{nombre}', ctx.nombre)
+      .replace('{curso}', ctx.tituloCurso)
+      .replace('{puesto}', ctx.puesto)
+      .replace('{fechainicio}', fechaLarga(ctx.ini))
+      .replace('{fechafin}', fechaLarga(ctx.fin))
+  );
+
+  const getBoxText = (id) => {
+    if (!previewEnt) return boxes[id]?.preview || '';
+    const ctx = buildTextContext(previewEnt);
+    if (id === 'nombre') return ctx.nombre;
+    if (id === 'mensaje') {
+      const ov = participantOverrides[previewEnt.id] || {};
+      const base = editId ? msgPdfEditing : (ov.msgPdf ?? cfg.mensajePDF);
+      const msg  = resolveMessage(base, ctx);
+      if (!msg || msg.includes('{')) {
+        return `Por su participación en “${ctx.tituloCurso}”, del ${fechaLarga(ctx.ini)} al ${fechaLarga(ctx.fin)}.`;
+      }
+      return msg;
+    }
+    if (id === 'fecha') return fechaLarga(ctx.fin);
+    return boxes[id]?.preview || '';
+  };
+
   // ============ ACCIONES ============
 
   const handlePreview = async () => {
@@ -795,7 +827,7 @@ export default function Constancias() {
                     padding: 2
                   }}
                 >
-                  {cfg.preview}
+                  {getBoxText(id)}
                 </div>
               </Rnd>
             ))}
@@ -850,7 +882,7 @@ export default function Constancias() {
                   }}
                   onClick={e=>{ e.stopPropagation(); setActiveBox(id); setPanelOpen(true); }}
                 >
-                  <div className="w-full h-full overflow-hidden break-all whitespace-pre-wrap"
+                <div className="w-full h-full overflow-hidden break-all whitespace-pre-wrap"
                     style={{
                       fontFamily: cfg.font,
                       fontSize: cfg.size,
@@ -860,7 +892,7 @@ export default function Constancias() {
                       padding: 2
                     }}
                   >
-                    {cfg.preview}
+                    {getBoxText(id)}
                   </div>
                 </Rnd>
               ))}

--- a/src/paginas/RegistroGrupo.jsx
+++ b/src/paginas/RegistroGrupo.jsx
@@ -371,25 +371,19 @@ export default function RegistroGrupo() {
                 <label className="block text-sm mb-1" style={{ color: theme.textColor || '#374151' }}>
                   Categoría *
                 </label>
-                {categorias.length > 0 ? (
-                  <select
-                    className="border rounded px-3 py-2 w-full"
-                    value={preset.categoria}
-                    onChange={(e) => setPreset((p) => ({ ...p, categoria: e.target.value }))}
-                    required
-                  >
-                    <option value="" disabled>Seleccione una categoría</option>
+                <input
+                  list="categorias-sugeridas"
+                  className="border rounded px-3 py-2 w-full"
+                  value={preset.categoria}
+                  onChange={(e) => setPreset((p) => ({ ...p, categoria: e.target.value }))}
+                  required
+                />
+                {categorias.length > 0 && (
+                  <datalist id="categorias-sugeridas">
                     {categorias.map((c) => (
-                      <option key={c} value={c}>{c}</option>
+                      <option key={c} value={c} />
                     ))}
-                  </select>
-                ) : (
-                  <input
-                    className="border rounded px-3 py-2 w-full"
-                    value={preset.categoria}
-                    onChange={(e) => setPreset((p) => ({ ...p, categoria: e.target.value }))}
-                    required
-                  />
+                  </datalist>
                 )}
               </div>
             )}

--- a/src/utilidades/useCourses.js
+++ b/src/utilidades/useCourses.js
@@ -86,6 +86,8 @@ export function useCourses() {
         imageUrl = await getDownloadURL(snapshot.ref);
       }
 
+      const categorias = Array.from(new Set(courseData.formularioGrupos?.categorias || []));
+
       await addDoc(collection(db, 'Cursos'), {
         cursoNombre: courseData.titulo,
         asesor: courseData.instructor,
@@ -102,17 +104,19 @@ export function useCourses() {
         theme: courseData.theme || {},
         encuestaId: courseData.encuestaId || '',
         encuestaLink: courseData.encuestaLink || '',
-        formularioGrupos: courseData.formularioGrupos || {
-          camposPreestablecidos: {
-            nombreEquipo: true,
-            nombreLider: true,
-            contactoEquipo: true,
-            categoria: true,
-            cantidadParticipantes: true,
-          },
-          preguntasPersonalizadas: [],
-          categorias: [],
-        },
+        formularioGrupos: courseData.formularioGrupos
+          ? { ...courseData.formularioGrupos, categorias }
+          : {
+              camposPreestablecidos: {
+                nombreEquipo: true,
+                nombreLider: true,
+                contactoEquipo: true,
+                categoria: true,
+                cantidadParticipantes: true,
+              },
+              preguntasPersonalizadas: [],
+              categorias,
+            },
         grupos: []
       });
 
@@ -142,6 +146,8 @@ export function useCourses() {
 
   const updateCourse = async (id, courseData, imageFile) => {
     const cRef = doc(db, 'Cursos', id);
+    const categorias = Array.from(new Set(courseData.formularioGrupos?.categorias || []));
+
     const updateData = {
       cursoNombre: courseData.titulo,
       asesor: courseData.instructor,
@@ -155,17 +161,19 @@ export function useCourses() {
       theme: courseData.theme || {},
       encuestaId: courseData.encuestaId || '',
       encuestaLink: courseData.encuestaLink || '',
-      formularioGrupos: courseData.formularioGrupos || {
-        camposPreestablecidos: {
-          nombreEquipo: true,
-          nombreLider: true,
-          contactoEquipo: true,
-          categoria: true,
-          cantidadParticipantes: true,
-        },
-        preguntasPersonalizadas: [],
-        categorias: [],
-      }
+      formularioGrupos: courseData.formularioGrupos
+        ? { ...courseData.formularioGrupos, categorias }
+        : {
+            camposPreestablecidos: {
+              nombreEquipo: true,
+              nombreLider: true,
+              contactoEquipo: true,
+              categoria: true,
+              cantidadParticipantes: true,
+            },
+            preguntasPersonalizadas: [],
+            categorias,
+          }
     };
 
     if (imageFile) {


### PR DESCRIPTION
## Resumen
- Mostrar datos reales de equipos o participantes al previsualizar constancias
- Guardar y deduplicar múltiples categorías en cursos
- Usar combo box con sugerencias para elegir categoría en registro de grupos

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6968183c08326aab572316365be09