### PR TITLE
Fix category options persistence in surveys

### DIFF
--- a/src/componentes/PantallaCursos/CourseModal.jsx
+++ b/src/componentes/PantallaCursos/CourseModal.jsx
@@ -127,6 +127,10 @@ export default function CourseModal({
     }
   }, [initialData, isOpen, resetState]);
 
+  useEffect(() => {
+    if (!isOpen) resetState();
+  }, [isOpen, resetState]);
+
   // Personal
   useEffect(() => {
     const fetchPersonal = async () => {

--- a/src/componentes/PantallaCursos/DetailsModal.jsx
+++ b/src/componentes/PantallaCursos/DetailsModal.jsx
@@ -112,54 +112,71 @@ export default function DetailsModal({
     try {
       let id = encuestaId;
       let link = encuestaLink;
+      const cats = Array.from(
+        new Set(
+          (data.formularioGrupos?.categorias || [])
+            .map((c) => (c || '').trim())
+            .filter(Boolean)
+        )
+      );
 
       if (!id) {
         const preguntas = mapPreguntasForSurvey();
         const res = await createForCourse({
-  cursoId: data.id,
-  titulo: `Registro de Grupos – ${data.titulo || ''}`,
-  descripcion: data.descripcion || '',
-  preguntas,
-  theme,
-  user: null,
-  // 🔽 añade:
-  cantidadParticipantes: data.formularioGrupos?.cantidadParticipantes ?? 1,
-  camposPreestablecidos: data.formularioGrupos?.camposPreestablecidos ?? {
-    nombreEquipo: true,
-    nombreLider: true,
-    contactoEquipo: true,
-    categoria: true,
-    cantidadParticipantes: true,
-  },
-});
+          cursoId: data.id,
+          titulo: `Registro de Grupos – ${data.titulo || ''}`,
+          descripcion: data.descripcion || '',
+          preguntas,
+          theme,
+          user: null,
+          cantidadParticipantes:
+            data.formularioGrupos?.cantidadParticipantes ?? 1,
+          camposPreestablecidos:
+            data.formularioGrupos?.camposPreestablecidos ?? {
+              nombreEquipo: true,
+              nombreLider: true,
+              contactoEquipo: true,
+              categoria: true,
+              cantidadParticipantes: true,
+            },
+          categorias: cats,
+        });
         id = res.id;
-        
       }
 
       // Construye link corto con slug
-      const slug = slugify(data.titulo || `curso-${data.id?.slice?.(0, 6) || ''}`);
+      const slug = slugify(
+        data.titulo || `curso-${data.id?.slice?.(0, 6) || ''}`
+      );
       const base = getBaseUrl();
       link = `${base}/${slug}`;
 
       // Guardar en colección 'encuestas'
       try {
-       await updateDoc(doc(db, 'encuestas', id), {
-  link,
-  linkSlug: slug,
-  theme,
-  titulo: `Registro de Grupos – ${data.titulo || ''}`,
-  descripcion: data.descripcion || '',
-  // 🔽 añade:
-  cantidadParticipantes: data.formularioGrupos?.cantidadParticipantes ?? 1,
-  camposPreestablecidos: data.formularioGrupos?.camposPreestablecidos ?? {
-    nombreEquipo: true,
-    nombreLider: true,
-    contactoEquipo: true,
-    categoria: true,
-    cantidadParticipantes: true,
-  },
-  updatedAt: new Date(),
-});
+        await updateDoc(doc(db, 'encuestas', id), {
+          link,
+          linkSlug: slug,
+          theme,
+          titulo: `Registro de Grupos – ${data.titulo || ''}`,
+          descripcion: data.descripcion || '',
+          cantidadParticipantes:
+            data.formularioGrupos?.cantidadParticipantes ?? 1,
+          camposPreestablecidos:
+            data.formularioGrupos?.camposPreestablecidos ?? {
+              nombreEquipo: true,
+              nombreLider: true,
+              contactoEquipo: true,
+              categoria: true,
+              cantidadParticipantes: true,
+            },
+          formularioGrupos: {
+            ...(data.formularioGrupos || {}),
+            cantidadParticipantes:
+              data.formularioGrupos?.cantidadParticipantes ?? 1,
+            categorias: cats,
+          },
+          updatedAt: new Date(),
+        });
       } catch (e) {
         console.warn('No se pudo actualizar la encuesta:', e);
       }

--- a/src/utilidades/useSurveys.js
+++ b/src/utilidades/useSurveys.js
@@ -77,11 +77,24 @@ export async function createForCourse({
   titulo,
   preguntas = [],
   user,
-  slug,           // opcional
-  theme,          // opcional: { headerTitle, headerDescription, backgroundImage, ... }
-  descripcion,    // opcional
+  slug, // opcional
+  theme, // opcional: { headerTitle, headerDescription, backgroundImage, ... }
+  descripcion, // opcional
+  cantidadParticipantes = 1,
+  camposPreestablecidos = {
+    nombreEquipo: true,
+    nombreLider: true,
+    contactoEquipo: true,
+    categoria: true,
+    cantidadParticipantes: true,
+  },
+  categorias = [],
 }) {
   const base = detectHashBase();
+
+  const cats = Array.from(
+    new Set(categorias.map((c) => (c || '').trim()).filter(Boolean))
+  );
 
   // 1) documento base
   const ref = await addDoc(collection(db, ENCUESTAS), {
@@ -89,6 +102,9 @@ export async function createForCourse({
     titulo: titulo || 'Registro de Grupos',
     descripcion: descripcion || '',
     preguntas,
+    cantidadParticipantes,
+    camposPreestablecidos,
+    formularioGrupos: { cantidadParticipantes, categorias: cats },
     creadoPor: user?.uid || null,
     creadoEn: serverTimestamp(),
   });


### PR DESCRIPTION
## Summary
- include category options when creating course surveys
- update survey generation to store participant count and category list
- reset course modal state on close to prevent leftover categories

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6a81f64f88326a0e09cd8c5ee788f