### PR TITLE
feat: allow configuring login route path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Configuración de la ruta de acceso
+
+El formulario de login puede exponerse en una ruta distinta sin modificar la lógica existente. Para ello se añadieron tres variables de entorno opcionales que se leen desde el cliente (usa un archivo `.env` o configura las variables en la plataforma donde desplegues la app):
+
+| Variable | Descripción | Valor por defecto |
+| --- | --- | --- |
+| `VITE_LOGIN_PATH` | Segmento de URL donde vivirá el formulario de login. Solo se toman en cuenta los caracteres después del dominio. | `login` |
+| `VITE_ROOT_REDIRECT_TO_LOGIN` | Controla si la ruta `/` redirige automáticamente hacia la ruta del login. Útil para ocultar la ubicación real del formulario. | `true` |
+| `VITE_KEEP_LEGACY_LOGIN_PATH` | Si se define en `true`, mantiene el camino antiguo `/login` como un alias que redirige al nuevo. Déjalo en `false` para ocultarlo. | `false` |
+
+Ejemplo de configuración para ocultar el acceso al panel:
+
+```ini
+VITE_LOGIN_PATH=panel-super-seguro
+VITE_ROOT_REDIRECT_TO_LOGIN=false
+```
+
+Con esos valores, la pantalla de autenticación quedará disponible en `https://tu-dominio/panel-super-seguro` y la ruta raíz (`/`) dejará de revelar automáticamente dicha dirección.

--- a/src/componentes/Topbar.jsx
+++ b/src/componentes/Topbar.jsx
@@ -6,6 +6,7 @@ import { AuthContext } from '../contexto/AuthContext';
 import { useNotifications } from '../contexto/NotificationContext';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../servicios/firebaseConfig';
+import { LOGIN_PATH } from '../utilidades/rutasConfig';
 
 export default function TopbarCompact({ isOpen }) {
   const { logout, usuario } = useContext(AuthContext);
@@ -53,7 +54,7 @@ export default function TopbarCompact({ isOpen }) {
 
   const handleLogout = () => {
     logout();
-    navigate('/login', { replace: true });
+    navigate(LOGIN_PATH, { replace: true });
   };
 
   return (

--- a/src/componentes/TopbarCompact.jsx
+++ b/src/componentes/TopbarCompact.jsx
@@ -6,6 +6,7 @@ import { AuthContext } from '../contexto/AuthContext';
 import { useNotifications } from '../contexto/NotificationContext';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../servicios/firebaseConfig';
+import { LOGIN_PATH } from '../utilidades/rutasConfig';
 
 export default function TopbarCompact({ isOpen }) {
   const { logout, usuario } = useContext(AuthContext);
@@ -53,7 +54,7 @@ export default function TopbarCompact({ isOpen }) {
 
   const handleLogout = () => {
     logout();
-    navigate('/login', { replace: true });
+    navigate(LOGIN_PATH, { replace: true });
   };
 
  return (

--- a/src/paginas/Inicio.jsx
+++ b/src/paginas/Inicio.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AuthContext } from '../contexto/AuthContext'
+import { LOGIN_PATH } from '../utilidades/rutasConfig'
 import {
   collection,
   onSnapshot,
@@ -29,7 +30,7 @@ export default function Inicio() {
 
   useEffect(() => {
     if (!usuario) {
-      navigate('/login', { replace: true })
+      navigate(LOGIN_PATH, { replace: true })
     } else {
       setUser(usuario)
     }
@@ -191,7 +192,7 @@ export default function Inicio() {
 
   const handleLogout = () => {
     logout()
-    navigate('/login', { replace: true })
+    navigate(LOGIN_PATH, { replace: true })
   }
 
   const proximosCursos = getProximosCursos()

--- a/src/paginas/Perfil.jsx
+++ b/src/paginas/Perfil.jsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AuthContext } from '../contexto/AuthContext'
 import { FaUser, FaEnvelope, FaLock, FaHistory, FaCamera, FaEdit } from 'react-icons/fa'
+import { LOGIN_PATH } from '../utilidades/rutasConfig'
 
 // 🔗 Firebase ------------------------------------------------------------
 import {
@@ -41,7 +42,7 @@ export default function Perfil () {
    *  -------------------------------------------------- */
   useEffect(() => {
     if (!usuario) {
-      navigate('/login', { replace: true })
+      navigate(LOGIN_PATH, { replace: true })
       return
     }
 

--- a/src/paginas/Personal.jsx
+++ b/src/paginas/Personal.jsx
@@ -8,6 +8,7 @@ import 'react-toastify/dist/ReactToastify.css';           // 🆕 estilos rápid
 import { AuthContext } from '../contexto/AuthContext';
 import { useParticipants } from '../utilidades/useParticipants';
 import { listToWorkbook, fileToList } from '../utilidades/excelHelpers';
+import { LOGIN_PATH } from '../utilidades/rutasConfig';
 
 import ParticipantList from '../componentes/PantallaPersonal/ParticipantList';
 import NewEditParticipantModal from '../componentes/PantallaPersonal/NewEditParticipantModal';
@@ -98,7 +99,7 @@ export default function Personal() {
   }, [participants]);
 
   /* ---------- seguridad ---------- */
-  if (!usuario) { navigate('/login', { replace:true }); return null; }
+  if (!usuario) { navigate(LOGIN_PATH, { replace:true }); return null; }
 
   /* ---------- handlers modales ---------- */
   const open  = (type,p=null)=>{ setSelected(p); setModalType(type); };

--- a/src/rutas/RutasApp.jsx
+++ b/src/rutas/RutasApp.jsx
@@ -14,14 +14,29 @@ import Equipos        from '../paginas/Equipos';
 import AsistenciaForm from '../paginas/AsistenciaForm';
 import Layout         from '../componentes/Layout';
 import RegistroGrupo  from '../paginas/RegistroGrupo';
+import {
+  LOGIN_PATH,
+  ROOT_REDIRECTS_TO_LOGIN,
+  KEEP_LEGACY_LOGIN_PATH,
+  LEGACY_LOGIN_PATH,
+} from '../utilidades/rutasConfig';
 
 export default function RutasApp() {
   const { usuario } = useContext(AuthContext);
 
+  const loginRoutes = [LOGIN_PATH];
+  if (KEEP_LEGACY_LOGIN_PATH && LOGIN_PATH !== LEGACY_LOGIN_PATH) {
+    loginRoutes.push(LEGACY_LOGIN_PATH);
+  }
+
+  const landingElement = ROOT_REDIRECTS_TO_LOGIN
+    ? <Navigate to={LOGIN_PATH} replace />
+    : <RegistroGrupo />;
+
   return (
     <Routes>
       {/* ---------- Rutas públicas ---------- */}
-      <Route path="/" element={<Navigate to="/login" replace />} />
+      <Route path="/" element={landingElement} />
 
       {/* Formulario por ID antiguo */}
       <Route path="/registro/:encuestaId" element={<RegistroGrupo />} />
@@ -33,10 +48,13 @@ export default function RutasApp() {
       <Route path="/asistencia/:cursoId" element={<AsistenciaForm />} />
 
       {/* Login */}
-      <Route
-        path="/login"
-        element={!usuario ? <Login /> : <Navigate to="/inicio" replace />}
-      />
+      {loginRoutes.map((path) => (
+        <Route
+          key={path}
+          path={path}
+          element={!usuario ? <Login /> : <Navigate to="/inicio" replace />}
+        />
+      ))}
 
       {/* ---------- Rutas protegidas (requieren login) ---------- */}
       {usuario && (
@@ -103,7 +121,7 @@ export default function RutasApp() {
       {/* ---------- Fallback ---------- */}
       <Route
         path="*"
-        element={usuario ? <Navigate to="/inicio" replace /> : <Navigate to="/login" replace />}
+        element={usuario ? <Navigate to="/inicio" replace /> : <Navigate to={LOGIN_PATH} replace />}
       />
     </Routes>
   );

--- a/src/utilidades/rutasConfig.js
+++ b/src/utilidades/rutasConfig.js
@@ -1,0 +1,15 @@
+// src/utilidades/rutasConfig.js
+// Centraliza configuraciones de rutas sensibles como la del login.
+
+const rawLoginPath = (import.meta.env.VITE_LOGIN_PATH ?? 'login').trim();
+const sanitizedLogin = rawLoginPath.replace(/^\/+/u, '').replace(/\/+$/u, '') || 'login';
+
+export const LOGIN_PATH = `/${sanitizedLogin}`;
+
+const rootRedirectSetting = import.meta.env.VITE_ROOT_REDIRECT_TO_LOGIN ?? 'true';
+export const ROOT_REDIRECTS_TO_LOGIN = rootRedirectSetting !== 'false';
+
+const legacySetting = import.meta.env.VITE_KEEP_LEGACY_LOGIN_PATH ?? 'false';
+export const KEEP_LEGACY_LOGIN_PATH = legacySetting === 'true';
+
+export const LEGACY_LOGIN_PATH = '/login';


### PR DESCRIPTION
## Summary
- add a shared route configuration helper so the login path can be set through environment variables
- update routing and navigation flows to honor the configurable login path and optional legacy alias
- document the new settings needed to hide the login URL when deploying the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caf8b618ac8326899013bab5b1e945